### PR TITLE
Categoryモデルに関するCRUD機能のAPIを実装

### DIFF
--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,1 +1,4 @@
-from . import *
+from .category import Category
+from .company import Company
+
+__all__ = ['Category', 'Company']

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,0 +1,2 @@
+from .category import CategorySerializer
+from .company import CompanySerializer

--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from api.models import Category
+
+class CategorySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Category
+        fields = '__all__'

--- a/api/serializers/company.py
+++ b/api/serializers/company.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from api.models import Company
+
+class CompanySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Company
+        fields = '__all__'

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,18 +1,80 @@
+from django.urls import reverse
 from rest_framework.test import APITestCase
-
+from api.models import Category, Company
 
 class CategoryViewTests(APITestCase):
+
+    def setUp(self):
+        self.company = Company.objects.create(name="CompanyTest1")
+
     def test_list(self):
+        url = reverse("category_list")
+
+        names = [
+            'カテゴリ1',
+            'カテゴリ2'
+        ]
+
+        for value in names:
+            Category.objects.create(name=value, company=self.company)
+    
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+        
+        for key,value in enumerate(names):
+            self.assertEqual(response.data[key]['name'], value)
+
         pass
 
     def test_retrieve(self):
+        category = Category.objects.create(name="カテゴリ1", company=self.company)
+        url = reverse("category_detail", kwargs={'pk': category.id})
+
+        response = self.client.get(url, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['name'], "カテゴリ1")
+
         pass
 
     def test_create(self):
+        url = reverse("category_list")
+        response = self.client.post(
+            url, 
+            {"name": "カテゴリ1", "company": self.company.id}, 
+            format="json"
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Category.objects.count(), 1)
+        self.assertEqual(Category.objects.get().name, "カテゴリ1")
+
         pass
 
     def test_update(self):
+        category = Category.objects.create(name="カテゴリ1", company=self.company)
+        url = reverse("category_detail", kwargs={'pk': category.id})
+
+        response = self.client.put(
+            url,
+            {"name": "カテゴリ1 更新", "company": self.company.id},
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        category.refresh_from_db()
+        self.assertEqual(category.name, "カテゴリ1 更新")
+
         pass
 
     def test_destroy(self):
+        category = Category.objects.create(name="カテゴリ1", company=self.company)
+        url = reverse("category_detail", kwargs={'pk': category.id})
+
+        response = self.client.delete(url, format="json")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(Category.objects.count(), 0)
+
         pass

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,15 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
+from .views.category import CategoryList, CategoryDetail
+from .views.company import CompanyList, CompanyDetail
 
 router = DefaultRouter()
 
-urlpatterns = [path("", include(router.urls))]
+urlpatterns = [
+    path("", include(router.urls)),
+    path("category/", CategoryList.as_view(), name="category_list"),
+    path("category/<uuid:pk>", CategoryDetail.as_view(), name="category_detail"),
+
+    path("company/", CompanyList.as_view(), name="company_list"),
+    path("company/<uuid:pk>", CompanyDetail.as_view(), name="company_detail"),
+]

--- a/api/views/__init__.py
+++ b/api/views/__init__.py
@@ -1,0 +1,2 @@
+from .category import *
+from .company import *

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,0 +1,12 @@
+from rest_framework import generics
+from api.models.category import Category
+from api.serializers import CategorySerializer
+
+
+class CategoryList(generics.ListCreateAPIView):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+
+class CategoryDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer

--- a/api/views/company.py
+++ b/api/views/company.py
@@ -1,0 +1,12 @@
+from rest_framework import generics
+from api.models.company import Company
+from api.serializers import CompanySerializer
+
+
+class CompanyList(generics.ListCreateAPIView):
+    queryset = Company.objects.all()
+    serializer_class = CompanySerializer
+
+class CompanyDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Company.objects.all()
+    serializer_class = CompanySerializer


### PR DESCRIPTION
### Model周り
* __init__.pyの追加

### Serializer
* CategorySerializerの追加
* [動作チェック用] CompanySerializerの追加

### Views
* Categoryに関するCRUD APIの実装
* [動作チェック用] Companyに関するCRUD APIの実装

### Test
* Categoryに関するCRUD APIテストの実装

