### PR TITLE
Category CRUDの追加

### DIFF
--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,1 +1,2 @@
-from . import *
+from .category import Category
+from .company import Company

--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from api.models import Category
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "updated_at"]

--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -1,3 +1,5 @@
+import unicodedata
+
 from rest_framework import serializers
 
 from api.models import Category
@@ -8,3 +10,11 @@ class CategorySerializer(serializers.ModelSerializer):
         model = Category
         fields = "__all__"
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    def validate_name(self, value):
+        if value:
+            # Convert full-width to half-width characters
+            value = unicodedata.normalize('NFKC', value)
+            # Strip whitespace
+            value = value.strip()
+        return value

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -39,3 +39,27 @@ class CategoryViewTests(APITestCase):
         url = reverse("category-detail", args=[category.id])
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_unique_constraint(self):
+        company = Company.objects.create(name="Test Company")
+        Category.objects.create(company=company, name="Duplicate Name")
+        url = reverse("category-list")
+        data = {"company": str(company.id), "name": "Duplicate Name"}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_name_strip_spaces(self):
+        company = Company.objects.create(name="Test Company")
+        url = reverse("category-list")
+        data = {"company": str(company.id), "name": "  Category Name  "}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "Category Name")
+
+    def test_fullwidth_to_halfwidth(self):
+        company = Company.objects.create(name="Test Company")
+        url = reverse("category-list")
+        data = {"company": str(company.id), "name": "ＡＢＣ１２３　テスト"}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "ABC123 テスト")

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,18 +1,41 @@
+from django.urls import reverse
+from rest_framework import status
 from rest_framework.test import APITestCase
+
+from api.models import Category, Company
 
 
 class CategoryViewTests(APITestCase):
     def test_list(self):
-        pass
+        url = reverse("category-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_retrieve(self):
-        pass
+        company = Company.objects.create(name="Test Company")
+        category = Category.objects.create(company=company, name="Test Category")
+        url = reverse("category-detail", args=[category.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_create(self):
-        pass
+        company = Company.objects.create(name="Test Company")
+        url = reverse("category-list")
+        data = {"company": str(company.id), "name": "New Category"}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_update(self):
-        pass
+        company = Company.objects.create(name="Test Company")
+        category = Category.objects.create(company=company, name="Test Category")
+        url = reverse("category-detail", args=[category.id])
+        data = {"company": str(company.id), "name": "Updated Category"}
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_destroy(self):
-        pass
+        company = Company.objects.create(name="Test Company")
+        category = Category.objects.create(company=company, name="Test Category")
+        url = reverse("category-detail", args=[category.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,9 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
+from api.views.category import CategoryViewSet
+
 router = DefaultRouter()
+router.register(r"categories", CategoryViewSet)
 
 urlpatterns = [path("", include(router.urls))]

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,0 +1,9 @@
+from rest_framework import viewsets
+
+from api.models import Category
+from api.serializers.category import CategorySerializer
+
+
+class CategoryViewSet(viewsets.ModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer


### PR DESCRIPTION
Categoryモデルに CRUD (Create, Read, Update, Delete) APIを実装しました。

### Serializer:

serializersに `fields = "__all__"` を設定しました。モデルにフィールドを追加したときなど便利な書き方ですが、もし秘匿したいフィールドが出てきた場合には注意が必要です

### Viewとルーティング:

Django REST Frameworkの `ViewSet` 機能を使って簡潔に記述しました。

### テスト:

既に用意していただいていたプレースホルダーに従って実装しました。

---

## ご検討ください

今回既に用意されていたmodelsに従って実装しましたが、現在の仕様では、*1つのカテゴリは1つの企業に属します*（1つの企業は複数のカテゴリを持てます）。これは「企業ごとの独自カテゴリ管理」を想定した設計と思われますが、もし「業界カテゴリ」のような共通カテゴリ（1つのカテゴリに複数の企業が属する）を想定している場合は、多対多のリレーション等への修正が必要です。

---

## 追加

バリデーションについてのリクエストを見落としていました。以下2点を提案いたします
- nameの前後に空白がある場合はstrip()
- 全角英数字を半角に変換する