### PR TITLE
Category の CRUD API とテストを追加

### DIFF
--- a/api/fixtures/categories.json
+++ b/api/fixtures/categories.json
@@ -1,0 +1,35 @@
+[
+{
+  "model": "api.category",
+  "pk": "4e63082b-99fe-41e4-a4ef-d8b38cbc6957",
+  "fields": {
+    "company": "c66d7482-3345-4ef5-94a1-392d94d5cb4c",
+    "name": "ルートA",
+    "parent_category": null,
+    "created_at": "2026-02-08T08:28:26.466Z",
+    "updated_at": "2026-02-08T08:28:26.466Z"
+  }
+},
+{
+  "model": "api.category",
+  "pk": "6662a64c-8a9d-4804-b379-568ffd40f534",
+  "fields": {
+    "company": "ab06a643-1ea4-4032-82c8-da77c5c41ef3",
+    "name": "ルートB",
+    "parent_category": null,
+    "created_at": "2026-02-08T08:28:44.093Z",
+    "updated_at": "2026-02-08T08:28:44.093Z"
+  }
+},
+{
+  "model": "api.category",
+  "pk": "c0ae0d0a-a8ba-4a1e-9447-69a4a6252ff0",
+  "fields": {
+    "company": "c66d7482-3345-4ef5-94a1-392d94d5cb4c",
+    "name": "子A",
+    "parent_category": "4e63082b-99fe-41e4-a4ef-d8b38cbc6957",
+    "created_at": "2026-02-08T08:28:30.077Z",
+    "updated_at": "2026-02-08T08:28:30.077Z"
+  }
+}
+]

--- a/api/fixtures/companies.json
+++ b/api/fixtures/companies.json
@@ -1,0 +1,20 @@
+[
+{
+  "model": "api.company",
+  "pk": "ab06a643-1ea4-4032-82c8-da77c5c41ef3",
+  "fields": {
+    "name": "B社",
+    "created_at": "2026-02-08T08:27:45.500Z",
+    "updated_at": "2026-02-08T08:27:45.500Z"
+  }
+},
+{
+  "model": "api.company",
+  "pk": "c66d7482-3345-4ef5-94a1-392d94d5cb4c",
+  "fields": {
+    "name": "A社",
+    "created_at": "2026-02-08T08:27:41.927Z",
+    "updated_at": "2026-02-08T08:27:41.927Z"
+  }
+}
+]

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,1 +1,3 @@
-from . import *
+# flake8: noqa: F401
+from .category import Category
+from .company import Company

--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -1,0 +1,29 @@
+from rest_framework import serializers
+
+from api.models import Category, Company
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    company = serializers.PrimaryKeyRelatedField(queryset=Company.objects.all())
+    parent_category = serializers.PrimaryKeyRelatedField(
+        queryset=Category.objects.all(),
+        allow_null=True,
+        required=False
+    )
+
+    class Meta:
+        model = Category
+        fields = [
+            "id",
+            "company",
+            "name",
+            "parent_category",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+    def validate(self, attrs):
+        # TODO
+
+        return attrs

--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -24,6 +24,27 @@ class CategorySerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_at", "updated_at"]
 
     def validate(self, attrs):
-        # TODO
+        company = attrs.get("company") or getattr(self.instance, "company", None)
+        parent_category = attrs.get("parent_category", getattr(self.instance, "parent_category", None))
+
+        # 親カテゴリの company チェック
+        if parent_category is not None and company is not None:
+            if parent_category.company_id != company.id:
+                raise serializers.ValidationError({"parent_category": "親カテゴリは同一企業のカテゴリのみ指定できます。"})
+
+        # 更新時に company を変更させない
+        if self.instance is not None and company is not None:
+            if company.id != self.instance.company_id:
+                raise serializers.ValidationError({"company": "更新時に company は変更できません。"})
+
+        # 自分自身 or 自分の子孫 を親にできない（循環参照防止）
+        if self.instance is not None and parent_category is not None:
+            cur = parent_category
+            while cur is not None:
+                if cur.id == self.instance.id:
+                    raise serializers.ValidationError(
+                        {"parent_category": "自分自身または自分の子孫カテゴリを親カテゴリには指定できません。"}
+                    )
+                cur = cur.parent_category
 
         return attrs

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -1,0 +1,57 @@
+import time
+
+from django.db import IntegrityError
+from django.test import TestCase
+
+from api.models import Company, Category
+
+
+class CategoryModelTest(TestCase):
+    def setUp(self):
+        self.company_a = Company.objects.create(name="A社")
+        self.company_b = Company.objects.create(name="B社")
+
+    def test_create_category_uuid_pk(self):
+        cat = Category.objects.create(company=self.company_a, name="営業", parent_category=None)
+        self.assertIsNotNone(cat.id)
+        self.assertEqual(len(str(cat.id)), 36)
+
+    def test_parent_category_can_be_null(self):
+        cat = Category.objects.create(company=self.company_a, name="ルート", parent_category=None)
+        self.assertIsNone(cat.parent_category)
+
+    def test_unique_constraint_company_and_name_duplicate_raises_integrity_error(self):
+        Category.objects.create(company=self.company_a, name="営業", parent_category=None)
+
+        with self.assertRaises(IntegrityError):
+            Category.objects.create(company=self.company_a, name="営業", parent_category=None)
+
+    def test_unique_constraint_allows_same_name_in_different_company(self):
+        Category.objects.create(company=self.company_a, name="営業", parent_category=None)
+        Category.objects.create(company=self.company_b, name="営業", parent_category=None)
+
+        self.assertEqual(Category.objects.filter(name="営業").count(), 2)
+
+    def test_created_at_is_not_changed_on_save(self):
+        cat = Category.objects.create(company=self.company_a, name="営業", parent_category=None)
+        created_before = cat.created_at
+
+        time.sleep(0.01)
+
+        cat.name = "営業(更新)"
+        cat.save()
+        cat.refresh_from_db()
+
+        self.assertEqual(cat.created_at, created_before)
+
+    def test_updated_at_changes_on_save(self):
+        cat = Category.objects.create(company=self.company_a, name="営業", parent_category=None)
+        updated_before = cat.updated_at
+
+        time.sleep(0.01)
+
+        cat.name = "営業(更新)"
+        cat.save()
+        cat.refresh_from_db()
+
+        self.assertGreater(cat.updated_at, updated_before)

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -1,0 +1,77 @@
+from django.test import TestCase
+from django.utils.dateparse import parse_datetime
+
+from api.models import Company, Category
+from api.serializers.category import CategorySerializer
+
+
+class CategorySerializerTest(TestCase):
+    def setUp(self):
+        self.company = Company.objects.create(name="A社")
+
+        self.root_category = Category.objects.create(
+            company=self.company,
+            name="親カテゴリ",
+            parent_category=None,
+        )
+        self.child_category = Category.objects.create(
+            company=self.company,
+            name="子カテゴリ",
+            parent_category=self.root_category,
+        )
+
+    def _assert_iso_datetime_string(self, value):
+        # DRFのDateTimeFieldは通常 ISO8601 文字列を返す
+        self.assertIsInstance(value, str)
+        # parseできることだけ確認（タイムゾーンの有無などは設定で変わるため）
+        dt = parse_datetime(value)
+        self.assertIsNotNone(dt, f"Invalid datetime string: {value}")
+
+    def test_serialized_keys(self):
+        serializer = CategorySerializer(instance=self.root_category)
+        data = serializer.data
+
+        expected_keys = {
+            "id",
+            "company",
+            "name",
+            "parent_category",
+            "created_at",
+            "updated_at",
+        }
+        self.assertEqual(set(data.keys()), expected_keys)
+
+    def test_serialize_root_category(self):
+        serializer = CategorySerializer(instance=self.root_category)
+        data = serializer.data
+
+        self.assertEqual(data["id"], str(self.root_category.id))
+        self.assertEqual(str(data["company"]), str(self.company.id))
+        self.assertEqual(data["name"], "親カテゴリ")
+        self.assertIsNone(data["parent_category"])
+        self._assert_iso_datetime_string(data["created_at"])
+        self._assert_iso_datetime_string(data["updated_at"])
+
+    def test_serialize_child_category(self):
+        serializer = CategorySerializer(instance=self.child_category)
+        data = serializer.data
+
+        self.assertEqual(data["id"], str(self.child_category.id))
+        self.assertEqual(str(data["company"]), str(self.company.id))
+        self.assertEqual(data["name"], "子カテゴリ")
+        self.assertEqual(str(data["parent_category"]), str(self.root_category.id))
+        self._assert_iso_datetime_string(data["created_at"])
+        self._assert_iso_datetime_string(data["updated_at"])
+
+    def test_serialize_many(self):
+        qs = Category.objects.filter(company=self.company).order_by("name")
+        serializer = CategorySerializer(instance=qs, many=True)
+        data = serializer.data
+
+        self.assertEqual(len(data), 2)
+
+        expected_ids = {
+            str(self.root_category.id),
+            str(self.child_category.id),
+        }
+        self.assertEqual({d["id"] for d in data}, expected_ids)

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -8,6 +8,7 @@ from api.serializers.category import CategorySerializer
 class CategorySerializerTest(TestCase):
     def setUp(self):
         self.company = Company.objects.create(name="A社")
+        self.company_b = Company.objects.create(name="B社")
 
         self.root_category = Category.objects.create(
             company=self.company,
@@ -18,6 +19,11 @@ class CategorySerializerTest(TestCase):
             company=self.company,
             name="子カテゴリ",
             parent_category=self.root_category,
+        )
+        self.root_category_b = Category.objects.create(
+            company=self.company_b,
+            name="B社の親カテゴリ",
+            parent_category=None,
         )
 
     def _assert_iso_datetime_string(self, value):
@@ -75,3 +81,112 @@ class CategorySerializerTest(TestCase):
             str(self.child_category.id),
         }
         self.assertEqual({d["id"] for d in data}, expected_ids)
+
+    def test_create_ok_parent_null(self):
+        data = {
+            "company": self.company.id,
+            "name": "新規カテゴリ",
+            "parent_category": None,
+        }
+        serializer = CategorySerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        obj = serializer.save()
+        self.assertEqual(obj.company_id, self.company.id)
+        self.assertEqual(obj.name, "新規カテゴリ")
+        self.assertIsNone(obj.parent_category)
+
+    def test_create_ok_parent_same_company(self):
+        data = {
+            "company": self.company.id,
+            "name": "A社の子カテゴリ",
+            "parent_category": self.root_category.id,
+        }
+        serializer = CategorySerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        obj = serializer.save()
+        self.assertEqual(obj.parent_category_id, self.root_category.id)
+
+    def test_create_ng_parent_different_company(self):
+        data = {
+            "company": self.company.id,
+            "name": "他社親はNG",
+            "parent_category": self.root_category_b.id,  # B社のカテゴリを親に指定
+        }
+        serializer = CategorySerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("parent_category", serializer.errors)
+
+    def test_create_ng_unique_company_name_duplicate(self):
+        data = {
+            "company": self.company.id,
+            "name": "子カテゴリ",
+            "parent_category": None,
+        }
+        serializer = CategorySerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("non_field_errors", serializer.errors)
+
+    def test_create_ok_same_name_different_company(self):
+        # A社にある名前でも、B社ならOK（ユニークは company + name）
+        data = {
+            "company": self.company_b.id,
+            "name": "子カテゴリ",
+            "parent_category": None,
+        }
+        serializer = CategorySerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_update_ng_different_company(self):
+        instance = self.root_category
+        data = {
+            "company": self.company_b.id,
+        }
+        serializer = CategorySerializer(instance=instance, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("company", serializer.errors)
+
+    def test_update_ng_parent_different_company(self):
+        instance = self.child_category
+        data = {
+            "parent_category": self.root_category_b.id,  # B社のカテゴリを親に指定
+        }
+        serializer = CategorySerializer(instance=instance, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("parent_category", serializer.errors)
+
+    def test_update_ok_same_values_on_self(self):
+        # 既存の値のまま更新（自分自身は除外されるのでOK）
+        instance = self.root_category
+        data = {"name": "親カテゴリ"}  # 同名だが自分自身
+        serializer = CategorySerializer(instance=instance, data=data, partial=True)
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_update_ng_unique_company_name_duplicate_excluding_self(self):
+        # name を更新するとA社内で衝突する
+        instance = self.child_category
+        data = {"name": "親カテゴリ"}
+        serializer = CategorySerializer(instance=instance, data=data, partial=True)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("non_field_errors", serializer.errors)
+
+    def test_update_ng_parent_is_self(self):
+        # 子カテゴリの親を自分自身にするのはNG
+        instance = self.child_category
+        data = {"parent_category": instance.id}
+        serializer = CategorySerializer(instance=instance, data=data, partial=True)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("parent_category", serializer.errors)
+
+    def test_update_ng_parent_is_ancestor(self):
+        # 親カテゴリの親を子カテゴリにするのはNG
+        instance = self.root_category
+        data = {"parent_category": self.child_category.id}
+        serializer = CategorySerializer(instance=instance, data=data, partial=True)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("parent_category", serializer.errors)

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -47,11 +47,84 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(res.data["name"], self.root_category_a.name)
         self.assertEqual(str(res.data["company"]), str(self.company_a.id))
 
-    def test_create(self):
-        pass
+    def test_create_ok_parent_null(self):
+        payload = {
+            "company": str(self.company_a.id),
+            "name": "新規カテゴリ",
+            "parent_category": None,
+        }
+        res = self.client.post('/api/categories/', payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
 
-    def test_update(self):
-        pass
+        created_id = res.data["id"]
+        obj = Category.objects.get(id=created_id)
+        self.assertEqual(obj.company_id, self.company_a.id)
+        self.assertEqual(obj.name, "新規カテゴリ")
+        self.assertIsNone(obj.parent_category)
 
-    def test_destroy(self):
-        pass
+    def test_create_ok_parent_same_company(self):
+        payload = {
+            "company": str(self.company_a.id),
+            "name": "A社の子カテゴリ",
+            "parent_category": str(self.root_category_a.id),
+        }
+        res = self.client.post('/api/categories/', payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+        obj = Category.objects.get(id=res.data["id"])
+        self.assertEqual(obj.parent_category_id, self.root_category_a.id)
+
+    def test_create_ng_parent_different_company(self):
+        payload = {
+            "company": str(self.company_a.id),
+            "name": "他社親はNG",
+            "parent_category": str(self.root_category_b.id),  # B社のカテゴリ
+        }
+        res = self.client.post('/api/categories/', payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("parent_category", res.data)
+
+    def test_create_ng_unique_company_name_duplicate(self):
+        payload = {
+            "company": str(self.company_a.id),
+            "name": self.root_category_a.name,
+            "parent_category": None,
+        }
+        res = self.client.post('/api/categories/', payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("non_field_errors", res.data)
+
+    def test_update_ok(self):
+        url = f'/api/categories/{self.child_category_a.id}/'
+        payload = {"name": "子A(更新)"}
+        res = self.client.patch(url, payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        self.child_category_a.refresh_from_db()
+        self.assertEqual(self.child_category_a.name, "子A(更新)")
+
+    def test_update_ng_parent_is_self(self):
+        url = f'/api/categories/{self.child_category_a.id}/'
+        payload = {
+            "parent_category": str(self.child_category_a.id),  # 自分を親に
+        }
+        res = self.client.patch(url, payload, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("parent_category", res.data)
+
+    def test_delete_ok(self):
+        url = f'/api/categories/{self.child_category_a.id}/'
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(Category.objects.filter(id=self.child_category_a.id).exists())
+
+    def test_delete_ng_with_children(self):
+        url = f'/api/categories/{self.root_category_a.id}/'
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertIn("detail", res.data)
+
+        self.assertTrue(Category.objects.filter(id=self.root_category_a.id).exists())
+        self.assertTrue(Category.objects.filter(id=self.child_category_a.id).exists())

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,12 +1,51 @@
+from rest_framework import status
 from rest_framework.test import APITestCase
+
+from api.models import Company, Category
 
 
 class CategoryViewTests(APITestCase):
-    def test_list(self):
-        pass
+    fixtures = ["companies.json", "categories.json"]
 
-    def test_retrieve(self):
-        pass
+    def setUp(self):
+        self.company_a = Company.objects.get(name="A社")
+        self.company_b = Company.objects.get(name="B社")
+
+        self.root_category_a = Category.objects.get(company=self.company_a, parent_category=None)
+        self.child_category_a = Category.objects.get(company=self.company_a, parent_category=self.root_category_a)
+
+        self.root_category_b = Category.objects.get(company=self.company_b, parent_category=None)
+
+    def test_list_returns_all_when_no_filter(self):
+        res = self.client.get('/api/categories/')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        returned_ids = {item["id"] for item in res.data}
+
+        self.assertIn(str(self.root_category_a.id), returned_ids)
+        self.assertIn(str(self.child_category_a.id), returned_ids)
+        self.assertIn(str(self.root_category_b.id), returned_ids)
+
+    def test_list_filters_by_company_query_param(self):
+        query = {
+            "company": str(self.company_a.id),
+        }
+        res = self.client.get('/api/categories/', query)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        returned_ids = {item["id"] for item in res.data}
+
+        self.assertIn(str(self.root_category_a.id), returned_ids)
+        self.assertIn(str(self.child_category_a.id), returned_ids)
+        self.assertNotIn(str(self.root_category_b.id), returned_ids)
+
+    def test_retrieve_ok(self):
+        res = self.client.get(f'/api/categories/{self.root_category_a.id}/')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(res.data["id"], str(self.root_category_a.id))
+        self.assertEqual(res.data["name"], self.root_category_a.name)
+        self.assertEqual(str(res.data["company"]), str(self.company_a.id))
 
     def test_create(self):
         pass

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,10 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
+from api.views.category import CategoryViewSet
+
 router = DefaultRouter()
+
+router.register("categories", CategoryViewSet, basename="category")
 
 urlpatterns = [path("", include(router.urls))]

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,3 +1,4 @@
+from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import ModelViewSet
 
 from api.models import Category
@@ -13,3 +14,10 @@ class CategoryViewSet(ModelViewSet):
         if company_id:
             qs = qs.filter(company_id=company_id)
         return qs
+
+    def perform_destroy(self, instance):
+        has_children = Category.objects.filter(parent_category=instance).exists()
+        if has_children:
+            raise ValidationError({"detail": "子カテゴリを持つカテゴリは削除できません。先に子カテゴリを削除または移動してください。"})
+
+        return super().perform_destroy(instance)

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,0 +1,15 @@
+from rest_framework.viewsets import ModelViewSet
+
+from api.models import Category
+from api.serializers.category import CategorySerializer
+
+
+class CategoryViewSet(ModelViewSet):
+    serializer_class = CategorySerializer
+
+    def get_queryset(self):
+        qs = Category.objects.select_related("company", "parent_category").order_by("-created_at")
+        company_id = self.request.query_params.get("company")
+        if company_id:
+            qs = qs.filter(company_id=company_id)
+        return qs


### PR DESCRIPTION
# 概要

Category モデルの読み取り・作成・更新・削除が出来る API を実装しました。

既存の設計・規約・依存関係を尊重して、直接関係しない変更（依存関係変更等）は原則行っていません。

# 追加した API の仕様

## 一覧
`GET /api/categories/?company=company_id`

`company` を指定しなければすべてのカテゴリを取得

## 取得
`GET /api/categories/{category_id}`

## 作成
`POST /api/categories/`

```json
{
    "company": company_id,
    "name": name,
    "parent_category": parent_category_id
}
```

- 同一 company 内ですでに同名のカテゴリがある場合は作成不可

## 更新
`PATCH /api/categories/{category_id}`

```json
{
    "name": name,
    "parent_category": parent_category_id
}
```

- company の変更は不可
- parent_category の変更は同一の company 内でのみ可能
- カテゴリの親子関係が循環参照するような変更は不可

## 削除
`DELETE /api/categories/{category_id}`

- 子カテゴリを持つカテゴリは削除不可

## 変更したファイル

- serializer と view を実装
  - api/serializers/category.py
  - api/views/category.py
  - api/tests/test_views.py

- model と serializer のテストを追加
  - api/tests/test_models.py
  - api/tests/test_serializers.py

- view のテストのため fixture を追加
  - api/fixtures/categories.json
  - api/fixtures/companies.json

- view を動かすためルーティングを修正
  - api/urls.py

- モデルクラスを import するように修正
  - api/models/\_\_init\_\_.py

`api/models/__init__.py` は、元のままでは makemigration が動かなかったので修正しました。
マイグレーション関係のファイルは本 PR には含めていませんが、モデルクラスのインポートパスの関係でこの変更のみ本 PR に含めています。
