### PR TITLE
Test toki

### DIFF
--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+
+from api.models.category import Category
+from api.models.company import Company
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    company = serializers.PrimaryKeyRelatedField(queryset=Company.objects.all())
+    parent_category = serializers.PrimaryKeyRelatedField(
+        queryset=Category.objects.all(),
+        allow_null=True,
+        required=False,
+    )
+
+    class Meta:
+        model = Category
+        fields = ["id", "company", "name", "parent_category", "created_at", "updated_at"]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+    def validate(self, attrs):
+        company = attrs.get("company", getattr(self.instance, "company", None))
+        name = attrs.get("name", getattr(self.instance, "name", None))
+
+        qs = Category.objects.filter(company=company, name=name)
+        if self.instance:
+            qs = qs.exclude(pk=self.instance.pk)
+
+        if qs.exists():
+            raise serializers.ValidationError({"name": "このカテゴリ名はすでに存在します。"})
+
+        return attrs

--- a/api/serializers/category.py
+++ b/api/serializers/category.py
@@ -8,8 +8,8 @@ class CategorySerializer(serializers.ModelSerializer):
     company = serializers.PrimaryKeyRelatedField(queryset=Company.objects.all())
     parent_category = serializers.PrimaryKeyRelatedField(
         queryset=Category.objects.all(),
-        allow_null=True,
-        required=False,
+        allow_null=True, # NULL を受け入れる（ルートカテゴリは親なし）
+        required=False, # リクエストボディに含まれなくてもエラーにしない
     )
 
     class Meta:
@@ -22,6 +22,8 @@ class CategorySerializer(serializers.ModelSerializer):
         name = attrs.get("name", getattr(self.instance, "name", None))
 
         qs = Category.objects.filter(company=company, name=name)
+
+        # 更新時に「自分自身と同じ name」は重複扱いにしないため
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -162,39 +162,12 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["name"], "ボトムス")
 
-    # --- destroy ---
-
-    # カテゴリを1件削除できること
-    def test_destroy(self):
+    # 存在しない parent_category IDを指定した場合は400が返ること
+    def test_partial_update_with_nonexistent_parent_category(self):
         url = reverse("category-detail", args=[self.category_tops.id])
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
-
-    # 存在しないIDで404が返ること
-    def test_destroy_not_found(self):
-        url = reverse("category-detail", args=[uuid.uuid4()])
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    # --- bulk_destroy ---
-
-    # 複数のカテゴリをまとめて削除できること
-    def test_bulk_destroy(self):
-        url = reverse("category-bulk-destroy")
-        data = {"ids": [self.category_ladies.id, self.category_tops.id]}
-        response = self.client.delete(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(Category.objects.filter(pk=self.category_ladies.id).exists())
-        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
-
-    # 存在しないIDが混じっていても、存在するものだけ削除されること
-    def test_bulk_destroy_skips_nonexistent_ids(self):
-        url = reverse("category-bulk-destroy")
-        data = {"ids": [self.category_tops.id, uuid.uuid4()]}
-        response = self.client.delete(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
+        data = {"parent_category": uuid.uuid4()}  # 存在しないID
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     # --- bulk_update ---
 
@@ -237,3 +210,74 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(len(response.data["errors"]), 1)
         self.assertEqual(response.data["errors"][0]["id"], str(self.category_tops.id))
         self.assertTrue(Category.objects.filter(pk=self.category_ladies.id, name="ボトムス").exists())
+
+    # 存在しないcompany IDを指定したレコードはerrorsに含まれ、有効なものは更新されること
+    def test_bulk_update_with_nonexistent_company(self):
+        url = reverse("category-bulk-update")
+        data = [
+            {"id": self.category_ladies.id, "name": "メンズ"},
+            {"id": self.category_tops.id, "company": uuid.uuid4()},  # 存在しないcompany
+        ]
+        response = self.client.patch(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 1)
+        self.assertEqual(len(response.data["errors"]), 1)
+        self.assertEqual(response.data["errors"][0]["id"], str(self.category_tops.id))
+
+    # 存在しないparent_category IDを指定したレコードはerrorsに含まれ、有効なものは更新されること
+    def test_bulk_update_with_nonexistent_parent_category(self):
+        url = reverse("category-bulk-update")
+        data = [
+            {"id": self.category_ladies.id, "name": "メンズ"},
+            {"id": self.category_tops.id, "parent_category": uuid.uuid4()},  # 存在しないparent_category
+        ]
+        response = self.client.patch(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 1)
+        self.assertEqual(len(response.data["errors"]), 1)
+        self.assertEqual(response.data["errors"][0]["id"], str(self.category_tops.id))
+
+    # companyにnullを指定した場合はerrorsに含まれること（companyは必須ForeignKey）
+    def test_bulk_update_with_null_company(self):
+        url = reverse("category-bulk-update")
+        data = [
+            {"id": self.category_tops.id, "company": None},
+        ]
+        response = self.client.patch(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["errors"]), 1)
+        self.assertEqual(response.data["errors"][0]["id"], str(self.category_tops.id))
+
+    # --- destroy ---
+
+    # カテゴリを1件削除できること
+    def test_destroy(self):
+        url = reverse("category-detail", args=[self.category_tops.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
+
+    # 存在しないIDで404が返ること
+    def test_destroy_not_found(self):
+        url = reverse("category-detail", args=[uuid.uuid4()])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- bulk_destroy ---
+
+    # 複数のカテゴリをまとめて削除できること
+    def test_bulk_destroy(self):
+        url = reverse("category-bulk-destroy")
+        data = {"ids": [self.category_ladies.id, self.category_tops.id]}
+        response = self.client.delete(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Category.objects.filter(pk=self.category_ladies.id).exists())
+        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
+
+    # 存在しないIDが混じっていても、存在するものだけ削除されること
+    def test_bulk_destroy_skips_nonexistent_ids(self):
+        url = reverse("category-bulk-destroy")
+        data = {"ids": [self.category_tops.id, uuid.uuid4()]}
+        response = self.client.delete(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -103,6 +103,72 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "トップス")
 
+    # --- list pagination ---
+
+    # limit と offset 両方指定で件数が絞られること
+    def test_list_with_limit_and_offset(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"limit": 2, "offset": 1})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    # limit のみ指定で先頭から指定件数返ること
+    def test_list_with_limit_only(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"limit": 2})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    # offset のみ指定で指定件数スキップして全件返ること
+    def test_list_with_offset_only(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"offset": 2})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    # offset がレコード件数を超えている場合は0件返ること
+    def test_list_with_offset_exceeding_total(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"offset": 100})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
+    # limit に文字列を指定した場合は400が返ること
+    def test_list_with_invalid_limit_string(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"limit": "abc"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # offset に文字列を指定した場合は400が返ること
+    def test_list_with_invalid_offset_string(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"offset": "abc"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # limit に空文字を指定した場合は400が返ること
+    def test_list_with_empty_limit(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"limit": ""})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # offset に空文字を指定した場合は400が返ること
+    def test_list_with_empty_offset(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"offset": ""})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # limit に0以下を指定した場合は400が返ること
+    def test_list_with_zero_limit(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"limit": 0})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # offset に負の数を指定した場合は400が返ること
+    def test_list_with_negative_offset(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"offset": -1})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     # --- create ---
 
     # カテゴリを1件作成できること

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -195,3 +195,45 @@ class CategoryViewTests(APITestCase):
         response = self.client.delete(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
+
+    # --- bulk_update ---
+
+    # 複数のカテゴリをまとめて更新できること
+    def test_bulk_update(self):
+        url = reverse("category-bulk-update")
+        data = [
+            {"id": self.category_ladies.id, "name": "メンズ"},
+            {"id": self.category_tops.id, "name": "ボトムス"},
+        ]
+        response = self.client.patch(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 2)
+        self.assertEqual(len(response.data["errors"]), 0)
+        self.assertTrue(Category.objects.filter(pk=self.category_ladies.id, name="メンズ").exists())
+        self.assertTrue(Category.objects.filter(pk=self.category_tops.id, name="ボトムス").exists())
+
+    # 存在しないIDはスキップして、存在するものだけ更新されること
+    def test_bulk_update_skips_nonexistent_ids(self):
+        url = reverse("category-bulk-update")
+        data = [
+            {"id": self.category_tops.id, "name": "ボトムス"},
+            {"id": uuid.uuid4(), "name": "存在しない"},
+        ]
+        response = self.client.patch(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 1)
+        self.assertTrue(Category.objects.filter(pk=self.category_tops.id, name="ボトムス").exists())
+
+    # バリデーションエラーのものはerrorsに含まれ、有効なものは更新されること
+    def test_bulk_update_returns_errors_for_invalid_records(self):
+        url = reverse("category-bulk-update")
+        data = [
+            {"id": self.category_ladies.id, "name": "ボトムス"},
+            {"id": self.category_tops.id, "name": "ファッション"},  # 企業A内で既存
+        ]
+        response = self.client.patch(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["updated"]), 1)
+        self.assertEqual(len(response.data["errors"]), 1)
+        self.assertEqual(response.data["errors"][0]["id"], str(self.category_tops.id))
+        self.assertTrue(Category.objects.filter(pk=self.category_ladies.id, name="ボトムス").exists())

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -33,6 +33,20 @@ class CategoryViewTests(APITestCase):
             name="食品",
             parent_category=None,
         )
+    # --- retrieve ---
+
+    # カテゴリIDで1件取得できること
+    def test_retrieve(self):
+        url = reverse("category-detail", args=[self.category_fashion.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "ファッション")
+
+    # 存在しないIDで404が返ること
+    def test_retrieve_not_found(self):
+        url = reverse("category-detail", args=[uuid.uuid4()])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # --- list ---
 
@@ -54,6 +68,14 @@ class CategoryViewTests(APITestCase):
     def test_list_filter_by_name(self):
         url = reverse("category-list")
         response = self.client.get(url, {"name": "トップス"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "トップス")
+
+        # 親カテゴリ名で絞り込めること
+    def test_list_filter_by_parent_category_name(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"parent_category_name": "レディース"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "トップス")
@@ -80,29 +102,6 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "トップス")
-
-    # 親カテゴリ名で絞り込めること
-    def test_list_filter_by_parent_category_name(self):
-        url = reverse("category-list")
-        response = self.client.get(url, {"parent_category_name": "レディース"})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["name"], "トップス")
-
-    # --- retrieve ---
-
-    # カテゴリIDで1件取得できること
-    def test_retrieve(self):
-        url = reverse("category-detail", args=[self.category_fashion.id])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["name"], "ファッション")
-
-    # 存在しないIDで404が返ること
-    def test_retrieve_not_found(self):
-        url = reverse("category-detail", args=[uuid.uuid4()])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # --- create ---
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -140,3 +140,21 @@ class CategoryViewTests(APITestCase):
         url = reverse("category-detail", args=[uuid.uuid4()])
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- bulk_destroy ---
+
+    def test_bulk_destroy(self):
+        url = reverse("category-bulk-destroy")
+        data = {"ids": [self.category_ladies.id, self.category_tops.id]}
+        response = self.client.delete(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Category.objects.filter(pk=self.category_ladies.id).exists())
+        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
+
+    # 「存在するものだけ削除」という仕様を明示的に確認するテスト
+    def test_bulk_destroy_skips_nonexistent_ids(self):
+        url = reverse("category-bulk-destroy")
+        data = {"ids": [self.category_tops.id, uuid.uuid4()]}
+        response = self.client.delete(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,18 +1,142 @@
+import uuid
+
+from django.urls import reverse
+from rest_framework import status
 from rest_framework.test import APITestCase
+
+from api.models.category import Category
+from api.models.company import Company
 
 
 class CategoryViewTests(APITestCase):
+    def setUp(self):
+        self.company_a = Company.objects.create(name="企業A")
+        self.company_b = Company.objects.create(name="企業B")
+
+        self.category_fashion = Category.objects.create(
+            company=self.company_a,
+            name="ファッション",
+            parent_category=None,
+        )
+        self.category_ladies = Category.objects.create(
+            company=self.company_a,
+            name="レディース",
+            parent_category=self.category_fashion,
+        )
+        self.category_tops = Category.objects.create(
+            company=self.company_a,
+            name="トップス",
+            parent_category=self.category_ladies,
+        )
+        self.category_food = Category.objects.create(
+            company=self.company_b,
+            name="食品",
+            parent_category=None,
+        )
+
+    # --- list ---
+
     def test_list(self):
-        pass
+        url = reverse("category-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 4)
+
+    def test_list_filter_by_company_id(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"company_id": self.company_a.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+
+    def test_list_filter_by_name(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"name": "トップス"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "トップス")
+
+    def test_list_filter_by_parent_category_name(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"parent_category_name": "レディース"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "トップス")
+
+    # --- retrieve ---
 
     def test_retrieve(self):
-        pass
+        url = reverse("category-detail", args=[self.category_fashion.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "ファッション")
+
+    def test_retrieve_not_found(self):
+        url = reverse("category-detail", args=[uuid.uuid4()])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- create ---
 
     def test_create(self):
-        pass
+        url = reverse("category-list")
+        data = {
+            "company": self.company_a.id,
+            "name": "メンズ",
+            "parent_category": self.category_fashion.id,
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], "メンズ")
+
+    def test_create_duplicate_name(self):
+        url = reverse("category-list")
+        data = {
+            "company": self.company_a.id,
+            "name": "ファッション",  # 企業A内で既存
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_invalid_company(self):
+        url = reverse("category-list")
+        data = {
+            "company": uuid.uuid4(),  # 存在しないcompany_id
+            "name": "メンズ",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # --- update (PUT) ---
 
     def test_update(self):
-        pass
+        url = reverse("category-detail", args=[self.category_tops.id])
+        data = {
+            "company": self.company_a.id,
+            "name": "ボトムス",
+            "parent_category": self.category_ladies.id,
+        }
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "ボトムス")
+
+    # --- partial_update (PATCH) ---
+
+    def test_partial_update(self):
+        url = reverse("category-detail", args=[self.category_tops.id])
+        data = {"name": "ボトムス"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "ボトムス")
+
+    # --- destroy ---
 
     def test_destroy(self):
-        pass
+        url = reverse("category-detail", args=[self.category_tops.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
+
+    def test_destroy_not_found(self):
+        url = reverse("category-detail", args=[uuid.uuid4()])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -36,18 +36,21 @@ class CategoryViewTests(APITestCase):
 
     # --- list ---
 
+    # フィルタなしで全件取得できること
     def test_list(self):
         url = reverse("category-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 4)
 
+    # 1つの企業IDで絞り込めること
     def test_list_filter_by_company_id(self):
         url = reverse("category-list")
         response = self.client.get(url, {"company_id": self.company_a.id})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
 
+    # カテゴリ名で絞り込めること
     def test_list_filter_by_name(self):
         url = reverse("category-list")
         response = self.client.get(url, {"name": "トップス"})
@@ -55,6 +58,30 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "トップス")
 
+    # 複数の企業IDで絞り込めること
+    def test_list_filter_by_multiple_company_ids(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"company_id": [self.company_a.id, self.company_b.id]})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 4)
+
+    # 複数の企業ID ＋ カテゴリ名で絞り込めること
+    def test_list_filter_by_multiple_company_ids_and_name(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"company_id": [self.company_a.id, self.company_b.id], "name": "トップス"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "トップス")
+
+    # 複数の企業ID ＋ 親カテゴリ名で絞り込めること
+    def test_list_filter_by_multiple_company_ids_and_parent_category_name(self):
+        url = reverse("category-list")
+        response = self.client.get(url, {"company_id": [self.company_a.id, self.company_b.id], "parent_category_name": "レディース"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "トップス")
+
+    # 親カテゴリ名で絞り込めること
     def test_list_filter_by_parent_category_name(self):
         url = reverse("category-list")
         response = self.client.get(url, {"parent_category_name": "レディース"})
@@ -64,12 +91,14 @@ class CategoryViewTests(APITestCase):
 
     # --- retrieve ---
 
+    # カテゴリIDで1件取得できること
     def test_retrieve(self):
         url = reverse("category-detail", args=[self.category_fashion.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["name"], "ファッション")
 
+    # 存在しないIDで404が返ること
     def test_retrieve_not_found(self):
         url = reverse("category-detail", args=[uuid.uuid4()])
         response = self.client.get(url)
@@ -77,6 +106,7 @@ class CategoryViewTests(APITestCase):
 
     # --- create ---
 
+    # カテゴリを1件作成できること
     def test_create(self):
         url = reverse("category-list")
         data = {
@@ -88,6 +118,7 @@ class CategoryViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data["name"], "メンズ")
 
+    # 同じ企業内で重複したカテゴリ名は作成できないこと
     def test_create_duplicate_name(self):
         url = reverse("category-list")
         data = {
@@ -97,6 +128,7 @@ class CategoryViewTests(APITestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    # 存在しない企業IDでは作成できないこと
     def test_create_invalid_company(self):
         url = reverse("category-list")
         data = {
@@ -108,6 +140,7 @@ class CategoryViewTests(APITestCase):
 
     # --- update (PUT) ---
 
+    # カテゴリを全フィールド更新できること
     def test_update(self):
         url = reverse("category-detail", args=[self.category_tops.id])
         data = {
@@ -121,6 +154,7 @@ class CategoryViewTests(APITestCase):
 
     # --- partial_update (PATCH) ---
 
+    # カテゴリを部分更新できること
     def test_partial_update(self):
         url = reverse("category-detail", args=[self.category_tops.id])
         data = {"name": "ボトムス"}
@@ -130,12 +164,14 @@ class CategoryViewTests(APITestCase):
 
     # --- destroy ---
 
+    # カテゴリを1件削除できること
     def test_destroy(self):
         url = reverse("category-detail", args=[self.category_tops.id])
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
 
+    # 存在しないIDで404が返ること
     def test_destroy_not_found(self):
         url = reverse("category-detail", args=[uuid.uuid4()])
         response = self.client.delete(url)
@@ -143,6 +179,7 @@ class CategoryViewTests(APITestCase):
 
     # --- bulk_destroy ---
 
+    # 複数のカテゴリをまとめて削除できること
     def test_bulk_destroy(self):
         url = reverse("category-bulk-destroy")
         data = {"ids": [self.category_ladies.id, self.category_tops.id]}
@@ -151,7 +188,7 @@ class CategoryViewTests(APITestCase):
         self.assertFalse(Category.objects.filter(pk=self.category_ladies.id).exists())
         self.assertFalse(Category.objects.filter(pk=self.category_tops.id).exists())
 
-    # 「存在するものだけ削除」という仕様を明示的に確認するテスト
+    # 存在しないIDが混じっていても、存在するものだけ削除されること
     def test_bulk_destroy_skips_nonexistent_ids(self):
         url = reverse("category-bulk-destroy")
         data = {"ids": [self.category_tops.id, uuid.uuid4()]}

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,14 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
+from api.views.category import CategoryViewSet
+
 router = DefaultRouter()
+# router.register(prefix, ViewSet, basename)
+# prefix: URLの先頭部分。"categories" なら /categories/ と /categories/{id}/ が生成される
+# ViewSet: 紐付けるViewSet
+# basename: URL名の接頭辞。get_queryset をオーバーライドしている場合は必須。
+#           例) basename="category" → "category-list", "category-detail" などのURL名が生成される
+router.register(r"categories", CategoryViewSet, basename="category")
 
 urlpatterns = [path("", include(router.urls))]

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,5 +1,6 @@
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from api.models.category import Category
@@ -25,6 +26,24 @@ class CategoryViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(name=name)
         if parent_category_name:
             queryset = queryset.filter(parent_category__name=parent_category_name)
+
+        offset_param = self.request.query_params.get("offset")
+        limit_param = self.request.query_params.get("limit")
+
+        # limit・offset が指定された場合、空文字とNoneを区別しintに変換できなければ400を返す。
+        try:
+            offset = int(offset_param) if offset_param is not None else 0
+            limit = int(limit_param) if limit_param is not None else None
+        except ValueError:
+            raise ValidationError("limitとoffsetは数値で入力してください")
+
+        if offset < 0 or (limit is not None and limit <= 0):
+            raise ValidationError("limitとoffsetは数値で入力してください")
+
+        if limit is not None:
+            queryset = queryset[offset:offset + limit]
+        else:
+            queryset = queryset[offset:]
 
         return queryset
 

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -34,3 +34,25 @@ class CategoryViewSet(viewsets.ModelViewSet):
         # 存在するものだけ削除
         Category.objects.filter(pk__in=ids).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=False, methods=["patch"], url_path="bulk-update")
+    def bulk_update(self, request):
+        updated = []
+        errors = []
+
+        for item in request.data:
+            item_id = item.get("id")
+            try:
+                instance = Category.objects.get(pk=item_id)
+            except Category.DoesNotExist:
+                # 存在しないIDはスキップ
+                continue
+
+            serializer = self.get_serializer(instance, data=item, partial=True)
+            if serializer.is_valid():
+                serializer.save()
+                updated.append(serializer.data)
+            else:
+                errors.append({"id": item_id, "errors": serializer.errors})
+
+        return Response({"updated": updated, "errors": errors}, status=status.HTTP_200_OK)

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,0 +1,27 @@
+from rest_framework import viewsets
+
+from api.models.category import Category
+from api.serializers.category import CategorySerializer
+
+
+# list, retrieve, create, update, partial_update, destroy の6つのアクションを一括で提供するため
+class CategoryViewSet(viewsets.ModelViewSet):
+    serializer_class = CategorySerializer
+
+    # メソッドでオーバーライドすることでリクエストごとに動的にフィルタを適用
+    def get_queryset(self):
+        # N+1問題が発生しないように
+        queryset = Category.objects.select_related("company", "parent_category")
+
+        company_id = self.request.query_params.get("company_id")
+        name = self.request.query_params.get("name")
+        parent_category_name = self.request.query_params.get("parent_category_name")
+
+        if company_id:
+            queryset = queryset.filter(company_id=company_id)
+        if name:
+            queryset = queryset.filter(name=name)
+        if parent_category_name:
+            queryset = queryset.filter(parent_category__name=parent_category_name)
+
+        return queryset

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -15,12 +15,12 @@ class CategoryViewSet(viewsets.ModelViewSet):
         # N+1問題が発生しないように
         queryset = Category.objects.select_related("company", "parent_category")
 
-        company_id = self.request.query_params.get("company_id")
+        company_ids = self.request.query_params.getlist("company_id")
         name = self.request.query_params.get("name")
         parent_category_name = self.request.query_params.get("parent_category_name")
 
-        if company_id:
-            queryset = queryset.filter(company_id=company_id)
+        if company_ids:
+            queryset = queryset.filter(company_id__in=company_ids)
         if name:
             queryset = queryset.filter(name=name)
         if parent_category_name:

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -1,4 +1,6 @@
-from rest_framework import viewsets
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from api.models.category import Category
 from api.serializers.category import CategorySerializer
@@ -25,3 +27,10 @@ class CategoryViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(parent_category__name=parent_category_name)
 
         return queryset
+
+    @action(detail=False, methods=["delete"], url_path="bulk-delete")
+    def bulk_destroy(self, request):
+        ids = request.data.get("ids", [])
+        # 存在するものだけ削除
+        Category.objects.filter(pk__in=ids).delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### todo
Categoryモデルの読み取り・作成・更新・削除 + test

### create
- [x] 一件のみの作成
- [x] test

### update
- [x] 一件のみの更新
- [x] 複数レコード更新
- [x] test

### delete
- [x] 一件のみの削除
- [x] 複数削除 
- [x] test

### read
retrieve
- [x] カテゴリIDで検索し、1件だけの取得

list
- [x] 1つの企業の全ての Categoryレコード取得 
- [x] 1つの企業の特定の親カテゴリ名に該当するCategoryレコード取得
- [x] 1つの企業の特定のカテゴリ名に該当するCategoryレコード取得（子カテゴリ）
- [x] 複数の企業の全ての Categoryレコード取得
- [x] 複数の企業の特定の親カテゴリ名に該当するCategoryレコード取得 
- [x] 複数の企業の特定のカテゴリ名に該当するCategoryレコード取得（子カテゴリ）
- [x] ページネーションがある場合の処理を追加（limit・offset）
- [x] test